### PR TITLE
Add Exposed port to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ COPY target/[PROJ_NAME_PLACEHOLDER]-1.0-SNAPSHOT.jar /app.jar
 
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+EXPOSE 8080


### PR DESCRIPTION
Currently we're using the `--expose` option in the `spring-container.sh` docker run command to expose the application port. We should change this to let the user decide what port to EXPOSE in the Dockerfile.

We should remove the `--expose` from the `spring-container.sh` script: https://github.com/eclipse/codewind/blob/master/src/pfe/file-watcher/scripts/spring-container.sh#L274